### PR TITLE
removing miner user and updating start script to enable msr support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG GIT_BRANCH_CUDA
 ENV DEBIAN_FRONTEND=noninteractive \
     GIT_REPOSITORY=${GIT_REPOSITORY_CUDA} \
     GIT_BRANCH=${GIT_BRANCH_CUDA}
-ENV CMAKE_FLAGS "-DCUDA_LIB=/usr/local/cuda/lib64/stubs/libcuda.so -DCMAKE_CXX_FLAGS=-std=c++11"
+ENV CMAKE_FLAGS "-DCMAKE_BUILD_TYPE=Release -DCUDA_LIB=/usr/local/cuda/lib64/stubs/libcuda.so -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda -DCMAKE_CXX_FLAGS=-std=c++11"
 ENV PACKAGE_DEPS "build-essential cmake git"
 
 WORKDIR /tmp
@@ -39,7 +39,7 @@ ARG GIT_BRANCH
 ENV DEBIAN_FRONTEND=noninteractive \
     GIT_REPOSITORY=${GIT_REPOSITORY} \
     GIT_BRANCH=${GIT_BRANCH}
-ENV CMAKE_FLAGS "-DWITH_OPENCL=ON -DWITH_CUDA=ON -DWITH_NVML=ON"
+ENV CMAKE_FLAGS "-DCMAKE_BUILD_TYPE=Release -DWITH_OPENCL=ON -DWITH_CUDA=ON -DWITH_NVML=ON"
 ENV PACKAGE_DEPS "build-essential ca-certificates cmake git libhwloc-dev libmicrohttpd-dev libssl-dev libuv1-dev ocl-icd-opencl-dev"
 
 COPY donate-level.patch /tmp
@@ -72,7 +72,7 @@ ENV AMDGPU_DRIVER_URI=https://www2.ati.com/drivers/linux/ubuntu/${AMDGPU_DRIVER_
 ENV PACKAGE_DEPS "ca-certificates libhwloc5 libmicrohttpd10 libssl1.0.0 libuv1 wget xz-utils"
 
 RUN set -x \
-  && adduser --system --disabled-password --home /config miner \
+  # && adduser --system --disabled-password --home /config miner \
   && dpkg --add-architecture i386 \
   && apt-get update -qq \
   && apt-get install -qq --no-install-recommends -y ${PACKAGE_DEPS} \
@@ -91,7 +91,7 @@ RUN set -x \
 COPY --from=build /tmp/xmrig/xmrig /usr/local/bin/
 COPY --from=build-cuda /tmp/xmrig-cuda/libxmrig-cuda.so /usr/local/lib
 
-USER miner
+# USER miner
 
 WORKDIR /config
 VOLUME /config

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,7 +9,7 @@ ARG GIT_BRANCH
 
 ENV GIT_REPOSITORY=${GIT_REPOSITORY} \
     GIT_BRANCH=${GIT_BRANCH}
-ENV CMAKE_FLAGS "-DWITH_OPENCL=OFF -DWITH_CUDA=OFF"
+ENV CMAKE_FLAGS "-DCMAKE_BUILD_TYPE=Release -DWITH_OPENCL=OFF -DWITH_CUDA=OFF -DWITH_NVML=OFF"
 
 COPY donate-level.patch /tmp
 
@@ -30,7 +30,7 @@ RUN  set -x \
 FROM alpine:${ALPINE_VERSION}
 
 RUN  set -x \
-  && adduser -S -D -h /config miner \
+  # && adduser -S -D -h /config miner \
   && apk update \
   && apk upgrade \
   && apk add --no-cache libmicrohttpd libuv openssl util-linux \
@@ -40,7 +40,7 @@ RUN  set -x \
 
 COPY --from=build /tmp/xmrig/xmrig /usr/local/bin/
 
-USER miner
+# USER miner
 
 WORKDIR /config
 VOLUME /config

--- a/start-xmrig.sh
+++ b/start-xmrig.sh
@@ -3,13 +3,33 @@
 TAG=${1:-latest}
 ADDRESS=${ADDRESS:-47NHecs6qjvDcbx3eW6cDGDwdm3gDqbHs7G8hzPYRxf3YRTcDJw8kXhDxfHinsjHUwVwdFusSn76UHkaz68KurUgHvFmPMH}
 HOST=${HOST:-$(hostname -s)}
-PORT=${PORT:-8080}
-POOL_HOST=${POOL:-ca.minexmr.com:5555}
-POOL_USER=${POOL_USER:-$ADDRESS.$HOST-$TAG}
-POOL_PASS=${POOL_PASS:-x}
-POOL_ALGO=${POOL_ALGO:-cn/r}
+
+REMOTE=${REMOTE:-pool.supportxmr.com:7777}
+REMOTE_USER=${REMOTE_USER:-$ADDRESS}
+REMOTE_PASS=${REMOTE_PASS:-$HOST:patricksissons@gmail.com}
+
+NAME=${NAME:-xmrig-$TAG}
+
+# setup msr
+# see: https://xmrig.com/docs/miner/randomx-optimization-guide/msr
+modprobe msr
+if cat /proc/cpuinfo | grep "AMD Ryzen" > /dev/null; then
+    echo "Detected Ryzen"
+    wrmsr -a 0xc0011022 0x510000
+    wrmsr -a 0xc001102b 0x1808cc16
+    wrmsr -a 0xc0011020 0
+    wrmsr -a 0xc0011021 0x40
+    echo "MSR register values for Ryzen applied"
+elif cat /proc/cpuinfo | grep "Intel" > /dev/null; then
+    echo "Detected Intel"
+    wrmsr -a 0x1a4 0xf
+    echo "MSR register values for Intel applied"
+else
+    echo "No supported CPU detected"
+fi
 
 # setup 1GB huge pages
+# see: https://xmrig.com/docs/miner/hugepages
 # make sure you also setup huge page support by running the command below
 #   sysctl -w vm.nr_hugepages=1280
 # or by updating /etc/sysctl.conf
@@ -19,6 +39,20 @@ for i in $(find /sys/devices/system/node/node* -maxdepth 0 -type d); do
     echo 3 > "$i/hugepages/hugepages-1048576kB/nr_hugepages";
 done
 
+# pull latest, remove existing container by same name, stop other running xmrig containers
 docker pull patsissons/xmrig:$TAG && \
-docker rm -f xmrig-$TAG 2> /dev/null && \
-docker run -it -d --name xmrig-$TAG -p $PORT:8080 patsissons/xmrig:$TAG -o $POOL_HOST -u $POOL_USER -p $POOL_PASS -a $POOL_ALGO --api-port 8080
+docker ps -aq --filter name=$NAME | xargs --no-run-if-empty docker rm -f && \
+docker ps -aq --filter name=xmrig --filter status=running | xargs --no-run-if-empty docker stop
+
+# start new container
+set -ex && \
+docker run \
+  --privileged -d --restart always \
+  -it --name $NAME \
+  -v xmrig-config:/config \
+  -v /lib/modules:/lib/modules:ro \
+  --runtime=nvidia \
+  --device /dev/dri --device /dev/kfd --group-add=video \
+  patsissons/xmrig:$TAG \
+  -o $REMOTE -u $REMOTE_USER -p $REMOTE_PASS -k \
+  --cuda --opencl --randomx-1gb-pages --no-nvml --print-time=60 --health-print-time=60


### PR DESCRIPTION
[`msr` support](https://xmrig.com/docs/miner/randomx-optimization-guide/msr) requires access to `/dev/cpu/*/msr` which cannot be accessed by the `miner` user. So instead we will run the container as `root`. I am also adding a volume mount for `/lib/modules` so that we can `modprobe msr` properly. I added a few other misc improvements to the CMAKE flags and the start script.